### PR TITLE
Follow Dockerfile best practices.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,112 +2,125 @@ FROM ubuntu:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Install tools and dependencies
-RUN apt-get --quiet --quiet update
-RUN apt-get --assume-yes upgrade
-RUN apt-get install --quiet --assume-yes python-dev python-setuptools python-pip libssl-dev libxml2-dev libxslt1-dev build-essential git imagemagick sqlite3 software-properties-common curl wget lsof language-pack-en pwgen couchdb
+# Install Cozy tools and dependencies.
+RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" >> /etc/apt/sources.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C \
+ && apt-get update --quiet \
+ && apt-get install --quiet --yes \
+  build-essential \
+  couchdb \
+  curl \
+  git \
+  imagemagick \
+  language-pack-en \
+  libssl-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  lsof \
+  nginx \
+  postfix \
+  pwgen \
+  python-dev \
+  python-pip \
+  python-setuptools \
+  python-software-properties \
+  software-properties-common \
+  sqlite3 \
+  wget
 RUN update-locale LANG=en_US.UTF-8
+RUN pip install \
+  supervisor \
+  virtualenv
 
-# Install NodeJS and NPM
-RUN cd /tmp && \
-wget http://nodejs.org/dist/v0.10.26/node-v0.10.26.tar.gz && \
-tar xvzf node-v0.10.26.tar.gz && \
-rm -f v0.10.26.tar.gz && \
-cd node-v0.10.26 && \
-./configure && \
-CXX="g++ -Wno-unused-local-typedefs" make && \
-CXX="g++ -Wno-unused-local-typedefs" make install && \
-cd /tmp && \
-rm -rf /tmp/node-v* && \
-npm install -g npm
+# Install NodeJS and NPM by building from source.
+RUN cd /tmp \
+ && wget -q -O - http://nodejs.org/dist/v0.10.26/node-v0.10.26.tar.gz | tar xz \
+ && cd node-v0.10.26 \
+ && ./configure \
+ && CXX="g++ -Wno-unused-local-typedefs" make \
+ && CXX="g++ -Wno-unused-local-typedefs" make install \
+ && cd .. \
+ && rm -rf /tmp/node-v* \
+ && npm install -g npm
 
-# Create Cozy users
-RUN useradd -M cozy
-RUN useradd -M cozy-data-system
-RUN useradd -M cozy-home
+# Install CoffeeScript, Cozy Monitor and Cozy Controller via NPM.
+RUN npm install -g \
+  coffee-script \
+  cozy-controller \
+  cozy-monitor
 
-# Configure CouchDB
-RUN mkdir /etc/cozy
-RUN pwgen -1 > /etc/cozy/couchdb.login
-RUN pwgen -1 >> /etc/cozy/couchdb.login
-RUN chown cozy-data-system /etc/cozy/couchdb.login
-RUN chmod 640 /etc/cozy/couchdb.login
-RUN mkdir /var/run/couchdb
-RUN chown -hR couchdb /var/run/couchdb
-RUN su - couchdb -c 'couchdb -b' && \
-sleep 5 && while ! curl -s 127.0.0.1:5984; do sleep 5; done && \
-curl -s -X PUT 127.0.0.1:5984/_config/admins/$(head -n1 /etc/cozy/couchdb.login) -d "\"$(tail -n1 /etc/cozy/couchdb.login)\""
+# Create Cozy users, without home directories.
+RUN useradd -M cozy \
+ && useradd -M cozy-data-system \
+ && useradd -M cozy-home
 
-# Install supevisord
-RUN pip install supervisor
+# Configure CouchDB.
+RUN mkdir /etc/cozy \
+ && chown -hR cozy /etc/cozy
+RUN pwgen -1 > /etc/cozy/couchdb.login \
+ && pwgen -1 >> /etc/cozy/couchdb.login \
+ && chown cozy-data-system /etc/cozy/couchdb.login \
+ && chmod 640 /etc/cozy/couchdb.login
+RUN mkdir /var/run/couchdb \
+ && chown -hR couchdb /var/run/couchdb \
+ && su - couchdb -c 'couchdb -b' \
+ && sleep 5 \
+ && while ! curl -s 127.0.0.1:5984; do sleep 5; done \
+ && curl -s -X PUT 127.0.0.1:5984/_config/admins/$(head -n1 /etc/cozy/couchdb.login) -d "\"$(tail -n1 /etc/cozy/couchdb.login)\""
+
+# Configure Supervisor.
 ADD supervisor/supervisord.conf /etc/supervisord.conf
-RUN mkdir -p /var/log/supervisor
-RUN chmod 777 /var/log/supervisor
-RUN /usr/local/bin/supervisord -c /etc/supervisord.conf
+RUN mkdir -p /var/log/supervisor \
+ && chmod 777 /var/log/supervisor \
+ && /usr/local/bin/supervisord -c /etc/supervisord.conf
 
-# Install CoffeeScript and Cozy Monitor via NPM
-RUN npm install -g coffee-script cozy-monitor
+# Install Cozy Indexer.
+RUN mkdir -p /usr/local/cozy-indexer \
+ && cd /usr/local/cozy-indexer \
+ && git clone https://github.com/cozy/cozy-data-indexer.git \
+ && cd /usr/local/cozy-indexer/cozy-data-indexer \
+ && virtualenv --quiet /usr/local/cozy-indexer/cozy-data-indexer/virtualenv \
+ && . ./virtualenv/bin/activate \
+ && pip install -r /usr/local/cozy-indexer/cozy-data-indexer/requirements/common.txt \
+ && chown -R cozy:cozy /usr/local/cozy-indexer
 
-# Install Cozy Controller via NPM
-RUN npm install -g cozy-controller
-
-# Install Cozy Indexer and its requirements via PIP
-RUN mkdir -p /usr/local/cozy-indexer
-RUN cd /usr/local/cozy-indexer && git clone https://github.com/cozy/cozy-data-indexer.git
-
-RUN cd /usr/local/cozy-indexer/cozy-data-indexer && \
-pip install virtualenv && \
-virtualenv --quiet /usr/local/cozy-indexer/cozy-data-indexer/virtualenv && \
-. ./virtualenv/bin/activate && \
-pip install  -r /usr/local/cozy-indexer/cozy-data-indexer/requirements/common.txt
-
-RUN chown -R cozy:cozy /usr/local/cozy-indexer
-
-# Start CouchDB, controller, indexer, then install the DS / Home / Proxy
+# Start up background services and install the Cozy platform apps.
 ENV NODE_ENV production
-RUN su - couchdb -c 'couchdb -b' && \
-sleep 5 && while ! curl -s 127.0.0.1:5984; do sleep 5; done && \
-/usr/local/lib/node_modules/cozy-controller/bin/cozy-controller & \
-sleep 5 && while ! curl -s 127.0.0.1:9002; do sleep 5; done && \
-cd /usr/local/cozy-indexer/cozy-data-indexer && \
-. ./virtualenv/bin/activate && \
-/usr/local/cozy-indexer/cozy-data-indexer/virtualenv/bin/python server.py & \
-sleep 5 && while ! curl -s 127.0.0.1:9102; do sleep 5; done && \
-cozy-monitor install data-system && \
-cozy-monitor install home && \
-cozy-monitor install proxy
+RUN su - couchdb -c 'couchdb -b' \
+ && sleep 5 \
+ && while ! curl -s 127.0.0.1:5984; do sleep 5; done \
+ && /usr/local/lib/node_modules/cozy-controller/bin/cozy-controller & sleep 5 \
+ && while ! curl -s 127.0.0.1:9002; do sleep 5; done \
+ && cd /usr/local/cozy-indexer/cozy-data-indexer \
+ && . ./virtualenv/bin/activate \
+ && /usr/local/cozy-indexer/cozy-data-indexer/virtualenv/bin/python server.py & sleep 5 \
+ && while ! curl -s 127.0.0.1:9102; do sleep 5; done \
+ && cozy-monitor install data-system \
+ && cozy-monitor install home \
+ && cozy-monitor install proxy
 
-# Install a late version of Nginx
-RUN apt-get install --quiet --assume-yes python-software-properties
-RUN add-apt-repository --yes ppa:nginx/stable
-RUN apt-get -qq update
-RUN apt-get install --quiet --assume-yes nginx
-RUN nginx -t
+# Generate an SSL certificate and the DH parameter.
+RUN openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/cozy/server.key -out /etc/cozy/server.crt -days 365 -subj '/CN=localhost' \
+ && openssl dhparam -out /etc/cozy/dh2048.pem -outform PEM -2 2048 \
+ && chown cozy:cozy /etc/cozy/server.key \
+ && chmod 600 /etc/cozy/server.key
 
-# Generate the SSL certificate and the DH parameter
-RUN chown -hR cozy /etc/cozy
-RUN openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/cozy/server.key -out /etc/cozy/server.crt -days 365 -subj '/CN=localhost'
-RUN openssl dhparam -out /etc/cozy/dh2048.pem -outform PEM -2 2048
-RUN chown cozy:cozy /etc/cozy/server.key
-RUN chmod 600 /etc/cozy/server.key
-
-# Configure Nginx and check configuration by restarting the service
+# Configure Nginx and check its configuration by restarting the service.
 ADD nginx/nginx.conf /etc/nginx/nginx.conf
 ADD nginx/cozy.conf /etc/nginx/sites-available/cozy.conf
-RUN chmod 0644 /etc/nginx/sites-available/cozy.conf
-RUN rm /etc/nginx/sites-enabled/default
-RUN ln -s /etc/nginx/sites-available/cozy.conf /etc/nginx/sites-enabled/cozy.conf
+RUN chmod 0644 /etc/nginx/sites-available/cozy.conf \
+ && rm /etc/nginx/sites-enabled/default \
+ && ln -s /etc/nginx/sites-available/cozy.conf /etc/nginx/sites-enabled/cozy.conf
 RUN nginx -t
 
-# Install Postfix with default parameters
+# Configure Postfix with default parameters.
 # TODO: Change mydomain.net?
-RUN echo "postfix postfix/mailname string mydomain.net" | debconf-set-selections
-RUN echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
-RUN echo "postfix postfix/destinations string mydomain.net, localhost.localdomain, localhost " | debconf-set-selections
-RUN apt-get install --quiet --assume-yes postfix
-RUN postfix check
+RUN echo "postfix postfix/mailname string mydomain.net" | debconf-set-selections \
+ && echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections \
+ && echo "postfix postfix/destinations string mydomain.net, localhost.localdomain, localhost " | debconf-set-selections \
+ && postfix check
 
-# Copy supervisord configuration files
+# Import Supervisor configuration files.
 ADD supervisor/cozy-controller.conf /etc/supervisor/conf.d/cozy-controller.conf
 ADD supervisor/cozy-indexer.conf /etc/supervisor/conf.d/cozy-indexer.conf
 ADD supervisor/couchdb.conf /etc/supervisor/conf.d/couchdb.conf
@@ -115,10 +128,9 @@ ADD supervisor/nginx.conf /etc/supervisor/conf.d/nginx.conf
 ADD supervisor/postfix.conf /etc/supervisor/conf.d/postfix.conf
 RUN chmod 0644 /etc/supervisor/conf.d/*
 
-# Clean APT cache for a lighter image
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
+# Clean APT cache for a lighter image.
+RUN apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 80 443
 


### PR DESCRIPTION
Thanks for writing a Dockerfile for Cozy!

I took the liberty to implement some [best practices](https://docs.docker.com/articles/dockerfile_best-practices/), including an improved handling of cache.

For example, the commands `apt-get update` and `apt-get install` should always be in the same `RUN` instruction, because they need to be executed approximately at the same time. Otherwise, the result of the `update` command will be cached and rarely invalidated, whereas the `install` command will be invalidated regularly (e.g. when new packets need to be installed), which cause network requests based on an outdated index. That's exactly what happened to me when I first tried your Dockerfile:

    Err http://archive.ubuntu.com/ubuntu/ trusty-security/main openssl amd64 1.0.1f-1ubuntu2.8
      404  Not Found [IP: 91.189.92.201 80]
    Err http://archive.ubuntu.com/ubuntu/ trusty-security/main libssl-dev amd64 1.0.1f-1ubuntu2.8
      404  Not Found [IP: 91.189.92.201 80]
    Err http://archive.ubuntu.com/ubuntu/ trusty-security/main libssl-doc all 1.0.1f-1ubuntu2.8
      404  Not Found [IP: 91.189.92.201 80]
    Err http://archive.ubuntu.com/ubuntu/ trusty-security/main python-requests all 2.2.1-1ubuntu0.1
      404  Not Found [IP: 91.189.92.201 80]
    Fetched 117 MB in 2min 55s (667 kB/s)
    E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/cups-filters/libcupsfilters1_1.0.52-0ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.91.24 80]
    E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.0.1f-1ubuntu2.8_amd64.deb  404  Not Found [IP: 91.189.92.201 80]
    E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.0.1f-1ubuntu2.8_amd64.deb  404  Not Found [IP: 91.189.92.201 80]
    E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-doc_1.0.1f-1ubuntu2.8_all.deb  404  Not Found [IP: 91.189.92.201 80]
    E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/requests/python-requests_2.2.1-1ubuntu0.1_all.deb  404  Not Found [IP: 91.189.92.201 80]
    E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Additional changes:
- Grouped all the installed packets into an alphabetically ordered list.
- Made command chains more readable.
- Used a `wget | tar` one-liner to avoid an unnecessary archive to be deleted.